### PR TITLE
Changes ls to /bin/ls to avoid problems when ls is aliased to /bin/ls…

### DIFF
--- a/docs/2021-lust/installation.md
+++ b/docs/2021-lust/installation.md
@@ -305,7 +305,7 @@ python3 -m pip install --ignore-installed --prefix $EB_TMPDIR easybuild
 ```shell
 # update environment to use this temporary EasyBuild installation
 export PATH=$EB_TMPDIR/bin:$PATH
-export PYTHONPATH=$(ls -rtd -1 $EB_TMPDIR/lib*/python*/site-packages | tail -1):$PYTHONPATH
+export PYTHONPATH=$(/bin/ls -rtd -1 $EB_TMPDIR/lib*/python*/site-packages | tail -1):$PYTHONPATH
 export EB_PYTHON=python3
 ```
 


### PR DESCRIPTION
Changes ls to /bin/ls to avoid problems when ls is aliased to /bin/ls --color in the second installation method, as PYTHONPATH would contain escape sequences.